### PR TITLE
Fix TypeScript build errors caused by verbatimModuleSyntax

### DIFF
--- a/frontend/src/components/CategoryFormModal.tsx
+++ b/frontend/src/components/CategoryFormModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Category, createCategory, updateCategory } from '../lib/api';
+import type { Category } from '../lib/api';
+import { createCategory, updateCategory } from '../lib/api';
 
 interface CategoryFormModalProps {
   isOpen: boolean;

--- a/frontend/src/components/ProductFormModal.tsx
+++ b/frontend/src/components/ProductFormModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Product, Category, createProduct, updateProduct } from '../lib/api';
+import type { Product, Category } from '../lib/api';
+import { createProduct, updateProduct } from '../lib/api';
 
 interface ProductFormModalProps {
   isOpen: boolean;

--- a/frontend/src/lib/cartStore.ts
+++ b/frontend/src/lib/cartStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { Product } from './api';
+import type { Product } from './api';
 
 interface CartItem {
   product: Product;

--- a/frontend/src/pages/admin/CategoriesPage.tsx
+++ b/frontend/src/pages/admin/CategoriesPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getAdminCategories, deleteCategory, Category } from '../../lib/api';
+import type { Category } from '../../lib/api';
+import { getAdminCategories, deleteCategory } from '../../lib/api';
 import CategoryFormModal from '../../components/CategoryFormModal';
 
 export default function CategoriesPage() {

--- a/frontend/src/pages/admin/OrdersPage.tsx
+++ b/frontend/src/pages/admin/OrdersPage.tsx
@@ -1,10 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getAdminOrders, updateOrderStatus, deleteOrder, OrderStatus, Order } from '../../lib/api';
+import type { Order, OrderStatus } from '../../lib/api';
+import { getAdminOrders, updateOrderStatus, deleteOrder } from '../../lib/api';
 
 export default function OrdersPage() {
   const queryClient = useQueryClient();
 
-  const { data: orders, isLoading, isError, error } = useQuery({
+  const { data: orders, isLoading, isError, error } = useQuery<Order[]>({
     queryKey: ['adminOrders'],
     queryFn: getAdminOrders,
   });

--- a/frontend/src/pages/admin/ProductsPage.tsx
+++ b/frontend/src/pages/admin/ProductsPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getAdminProducts, getAdminCategories, deleteProduct, Product } from '../../lib/api';
+import type { Product } from '../../lib/api';
+import { getAdminProducts, getAdminCategories, deleteProduct } from '../../lib/api';
 import ProductFormModal from '../../components/ProductFormModal';
 
 export default function ProductsPage() {

--- a/frontend/src/pages/admin/SettingsPage.tsx
+++ b/frontend/src/pages/admin/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { getAdminSettings, updateAdminSettings, StoreSettings } from '../../lib/api';
+import type { StoreSettings } from '../../lib/api';
+import { getAdminSettings, updateAdminSettings } from '../../lib/api';
 import { useEffect, useState } from 'react';
 
 export default function SettingsPage() {


### PR DESCRIPTION
The TypeScript compiler option `verbatimModuleSyntax` was enabled, which requires that type-only imports be made with `import type`.

This commit fixes all instances of mixed type and value imports by separating them into distinct `import type` and `import` statements.

This resolves the TS1484 errors and allows the frontend to build successfully.