### PR TITLE
feat: set default backend api url to production

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000'
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'https://api.azhar.store'
 
 // --- Types based on backend schemas ---
 export interface Category {


### PR DESCRIPTION
Sets the default backend API URL in the frontend to `https://api.azhar.store`. This is done by changing the fallback value in `frontend/src/lib/api.ts`.