### PR TITLE
fix(backend): Change port to 80 to fix 502 error

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,5 +3,5 @@ WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . /app
-EXPOSE 8000
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+EXPOSE 80
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80"]


### PR DESCRIPTION
The application was encountering a 502 Bad Gateway error when deployed. This was likely due to the reverse proxy (Dokploy) being unable to connect to the backend container. The proxy was probably trying to connect on the default port 80, while the application was configured to listen on port 8000.

This commit changes the backend to run on port 80, which should allow the reverse proxy to connect successfully.