### PR TITLE
fix(backend): Configure Nginx as a reverse proxy and update backend port

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,5 +3,5 @@ WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . /app
-EXPOSE 80
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80"]
+EXPOSE 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,7 +9,7 @@ class Settings(BaseSettings):
     DATABASE_URL: str
     ADMIN_PASSWORD: str
     AZHAR_ADMIN_EMAIL: str
-    CORS_ORIGINS: str = "*"
+    CORS_ORIGINS: str = "https://beta.azhar.store"
 
     # JWT settings
     SECRET_KEY: str = "a_very_secret_key"  # Should be overridden in .env for production

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,21 +1,12 @@
 server {
-  listen 80;
-  server_name localhost;
+    listen 80;
+    server_name api.azhar.store;
 
-  # Root directory for the static files
-  root /usr/share/nginx/html;
-  index index.html;
-
-  # This is the crucial part for single-page applications (SPAs)
-  # It ensures that any request that doesn't match a static file
-  # is redirected to index.html, allowing React Router to handle it.
-  location / {
-    try_files $uri $uri/ /index.html;
-  }
-
-  # Optional: Add headers to prevent caching issues
-  location ~* \.(?:ico|css|js|gif|jpe?g|png)$ {
-    expires 1y;
-    add_header Cache-Control "public";
-  }
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 }


### PR DESCRIPTION
This commit addresses the deployment issue where the backend service was serving a default Nginx page instead of the API.

The changes include:
- Modifying the `frontend/nginx.conf` to act as a reverse proxy, forwarding all requests to the backend application.
- Updating the `backend/Dockerfile` to run the FastAPI application on port 8000 to avoid conflicts with Nginx on port 80.
- Refining the CORS configuration in `backend/app/config.py` to be more specific, allowing requests only from the frontend domain `https://beta.azhar.store`.

These changes will ensure that the backend deployment correctly serves the API and can be accessed by the frontend. The user will need to ensure their deployment environment runs both the Nginx and the backend uvicorn processes.