### PR TITLE
fix(nginx): Correct Nginx proxy paths for API endpoints

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -2,8 +2,29 @@ server {
     listen 80;
     server_name api.azhar.store;
 
-    location / {
-        proxy_pass http://127.0.0.1:8000;
+    # Proxy requests for the API
+    location /api/ {
+        proxy_pass http://127.0.0.1:8000/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Handle the root path separately to show API status
+    location = / {
+        # Use a try_files to avoid passing a request body for a GET request
+        # or simply proxy to the root of the backend.
+        proxy_pass http://127.0.0.1:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Optional: Add a health check endpoint
+    location = /health {
+        proxy_pass http://127.0.0.1:8000/health;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This commit corrects the Nginx configuration to properly handle API routing.

The previous configuration used a single `location /` block, which caused all requests to be forwarded to the root of the backend application.

The updated `frontend/nginx.conf` now includes specific location blocks:
- `location /api/` ensures that requests to API endpoints are correctly proxied to the backend with the full path preserved.
- `location = /` and `location = /health` handle the root and health check endpoints separately.

This change ensures that API calls from the frontend (e.g., to `/api/products`) are routed to the correct handlers in the FastAPI application.