### PR TITLE
feat: Create unified Dockerfile for backend and nginx proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Base image with Python
+FROM python:3.11-slim
+
+# Install Nginx
+RUN apt-get update && apt-get install -y nginx && apt-get clean
+
+# Set working directory
+WORKDIR /app
+
+# Install Python dependencies
+# Copy requirements first to leverage Docker cache
+COPY backend/requirements.txt /app/backend/requirements.txt
+RUN pip install --no-cache-dir -r backend/requirements.txt
+
+# Copy the rest of the application code
+COPY . /app
+
+# Copy Nginx configuration
+# The previous fix to this file makes it a reverse proxy
+COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Copy and make the startup script executable
+COPY start.sh /app/start.sh
+RUN chmod +x /app/start.sh
+
+# Expose port 80 for Nginx
+EXPOSE 80
+
+# Run the startup script
+CMD ["/app/start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# Start the Uvicorn server in the background
+echo "Starting Uvicorn server..."
+(cd backend && uvicorn main:app --host 0.0.0.0 --port 8000) &
+
+# Start Nginx in the foreground
+echo "Starting Nginx server..."
+nginx -g 'daemon off;'


### PR DESCRIPTION
This commit introduces a new deployment strategy for the backend service to resolve the longstanding Nginx and CORS issues.

The root cause of the problem was that the deployment was only running an Nginx container, without the Python backend application.

This commit fixes the issue by:
1.  Creating a new `Dockerfile` in the project root that builds a single container with both Python and Nginx installed.
2.  Adding a `start.sh` script that starts the `uvicorn` backend process in the background and the `nginx` server in the foreground.
3.  The previously corrected `frontend/nginx.conf` is now used by this new Dockerfile to correctly reverse proxy API requests to the backend.

To use this fix, the deployment service (dokploy) for the `api.azhar.store` backend must be configured to use the `Dockerfile` from the root of the repository.