### PR TITLE
fix(deps): Correct passlib version in requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,4 +9,4 @@ psycopg2-binary==2.9.9
 asyncpg==0.29.0
 SQLAlchemy==2.0.31
 python-jose[cryptography]==3.3.0
-passlib[bcrypt]==2024.1
+passlib[bcrypt]


### PR DESCRIPTION
This commit resolves a Docker build failure caused by an invalid version specifier for the `passlib` package.

The `backend/requirements.txt` file specified `passlib[bcrypt]==2024.1`, which does not exist in the package repository. This has been corrected to `passlib[bcrypt]`, allowing the package manager to install the latest available version.

This change, combined with the previous commits to create a unified Dockerfile, should result in a successful deployment of the backend service.