### PR TITLE
fix: Disable statement cache for Supabase/pgbouncer compatibility

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -13,7 +13,11 @@ if not DATABASE_URL:
 # The DATABASE_URL for Supabase should be a PostgreSQL connection string
 # e.g., "postgresql+asyncpg://user:password@host:port/database"
 
-engine = create_async_engine(DATABASE_URL, echo=True)
+engine = create_async_engine(
+    DATABASE_URL,
+    echo=True,
+    connect_args={"statement_cache_size": 0}
+)
 AsyncSessionLocal = sessionmaker(
     autocommit=False, autoflush=False, bind=engine, class_=AsyncSession
 )


### PR DESCRIPTION
This commit resolves the `DuplicatePreparedStatementError` that occurs when using the Supabase connection pooler.

The issue is caused by an incompatibility between SQLAlchemy's use of prepared statement caching and pgbouncer's transaction-level pooling. The fix, as recommended by the `asyncpg` error message, is to disable statement caching in the database driver.

The `create_async_engine` call in `backend/app/db.py` has been updated to include `connect_args={'statement_cache_size': 0}`.

This commit, combined with the previous fixes, should result in a fully functional and stable backend deployment.