### PR TITLE
Fix Docker build by moving and correcting Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.11-slim
 WORKDIR /app
-COPY requirements.txt /app/requirements.txt
+COPY backend/requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
-COPY . /app
+COPY backend/ /app/
 EXPOSE 8000
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
This commit resolves a critical deployment issue where the Docker build was failing because it could not find the `Dockerfile` in the repository root.

The `Dockerfile` has been moved from `backend/Dockerfile` to the root directory (`/Dockerfile`) to match the path expected by the user's Dokploy configuration.

The paths inside the `Dockerfile` have also been corrected to account for the new build context (the repository root). The `COPY` commands now correctly reference `backend/requirements.txt` and the `backend/` directory to ensure the application files are placed in the correct location within the container.

This change should allow the user's deployment pipeline to successfully build and deploy the application, finally enabling all the previous bug fixes to take effect.