### PR TITLE
Fix: Add pgbouncer compatibility for Supabase

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -14,8 +14,12 @@ if not DATABASE_URL:
 # The DATABASE_URL for Supabase should be a PostgreSQL connection string
 # e.g., "postgresql+asyncpg://user:password@host:port/database"
 
+engine_args = {"echo": True}
+if DATABASE_URL and DATABASE_URL.startswith("postgresql"):
+    engine_args["connect_args"] = {"statement_cache_size": 0}
+
 engine = create_async_engine(
-    DATABASE_URL, echo=True
+    DATABASE_URL, **engine_args
 )
 AsyncSessionLocal = sessionmaker(
     autocommit=False, autoflush=False, bind=engine, class_=AsyncSession


### PR DESCRIPTION
This commit fixes a `DuplicatePreparedStatementError` that occurs when connecting to a Supabase database that uses pgbouncer for connection pooling.

The fix involves conditionally setting `statement_cache_size=0` in the SQLAlchemy engine connection arguments only when a PostgreSQL database is being used. This disables prepared statements on the client side, which is the recommended way to resolve this incompatibility with pgbouncer's transaction and statement pooling modes.

This change ensures the application can run correctly in both local SQLite environments and production Supabase environments.