### PR TITLE
Fix: Add cache buster to Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,11 @@
 FROM python:3.11-slim
 WORKDIR /app
+
+# --- Cache Buster ---
+# This line forces the Docker cache to be invalidated for subsequent layers.
+ARG CACHE_BUSTER=1
+# ---
+
 COPY requirements.txt /app/requirements.txt
 RUN apt-get update && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements.txt


### PR DESCRIPTION
This commit adds an ARG instruction to the `backend/Dockerfile`. This acts as a cache buster, forcing Docker to re-evaluate subsequent layers during the build process.

This is intended to solve a persistent deployment issue where old, cached layers of the application code were being used instead of the latest version, preventing bug fixes from being applied.